### PR TITLE
Add Japanese references

### DIFF
--- a/ja/index.html
+++ b/ja/index.html
@@ -42,10 +42,17 @@
         </p>
         <p>
           参考：
-          <ul>
-            <li><a href="https://www.clear-code.com/blog/2015/12/12.html">RubyKaigi 2015：The history of testing framework in Ruby</a></li>
-            <li><a href="https://www.clear-code.com/blog/2014/11/6.html">Rubyのテスティングフレームワークの歴史（2014年版） - ククログ(2014-11-06)</a></li>
-          </ul>
+          <dl>
+            <dt>test-unit の歴史</dt>
+            <dd><a href="https://www.clear-code.com/blog/2015/12/12.html">RubyKaigi 2015：The history of testing framework in Ruby</a></dd>
+            <dd><a href="https://www.clear-code.com/blog/2014/11/6.html">Rubyのテスティングフレームワークの歴史（2014年版） - ククログ(2014-11-06)</a></dd>
+            <dt>おすすめの機能や使い方</dt>
+            <dd><a href="https://www.clear-code.com/blog/2018/12/26.html">Ruby 2.6.0とtest-unitとデータ駆動テスト (3.2.9 以降で使えます)</a></dd>
+            <dd><a href="https://www.clear-code.com/blog/2013/1/23.html">Ruby用単体テストフレームワークtest-unitでのデータ駆動テストの紹介 (2.3.1 以降で使えます)</a></dd>
+            <dd><a href="https://www.clear-code.com/blog/2011/2/28.html">デバッグしやすいassert_equalの書き方</a></dd>
+            <dt>他のフレームワークとの比較</dt>
+            <dd><a href="https://www.clear-code.com/blog/2014/3/19.html">test-unitならRSpec 3のComposable Matchers相当のことをどう書くか</a></dd>
+          </dl>
         </p>
         <h2 id="backward-compatibility">後方互換性</h2>
         <p>


### PR DESCRIPTION
#42 から、更に日本語の参考資料へのリンクを増やしてみました！

* この数になるとジャンル分けした方が読みやすいかなと思い、 ul & li ではなく dl & dt & dd を使ってみました。 
* `他のフレームワークとの比較` に https://www.clear-code.com/blog/2008/11/10.html も載せようかと思ったのですが、対象の test-unit と rspec 双方のバージョンが既にかなり古いこともありやめておきました。

どうでしょう？

個人的には https://www.clear-code.com/blog/2013/1/23.html は把握していたのですが、 https://www.clear-code.com/blog/2018/12/26.html は知らなかったので、役立つ方は多いのではないか？と思っています 🙏 (データ表の考え方はちょっと難しくて、まだ自分でも使いこなせそうには無いのですが・・・)